### PR TITLE
Use FontAwesome icons as bullets in Resources list

### DIFF
--- a/Views/Home/Resources.cshtml
+++ b/Views/Home/Resources.cshtml
@@ -2,35 +2,35 @@
 
 <p>Here is a list of codingteam affiliated online resources:</p>
 
-<ul>
+<ul class="fa-ul">
     <li>
         <a href="https://github.com/codingteam/">
-            <i class="fa fa-github"></i> GitHub organization
+            <i class="fa-li fa fa-github"></i> GitHub organization
         </a>
     </li>
     <li>
         <a href="https://gitter.im/codingteam">
-            <i class="fa fa-users"></i> Gitter room
+            <i class="fa-li fa fa-users"></i> Gitter room
         </a>
     </li>
     <li>
         <a href="https://bitbucket.org/codingteam">
-            <i class="fa fa-bitbucket"></i> Bitbucket team
+            <i class="fa-li fa fa-bitbucket"></i> Bitbucket team
         </a>
     </li>
     <li>
         <a href="https://gitlab.com/groups/codingteam">
-            <i class="fa fa-code-fork"></i> GitLab team
+            <i class="fa-li fa fa-code-fork"></i> GitLab team
         </a>
     </li>
     <li>
         <a href="http://www.loglist.net/">
-            <i class="fa fa-ambulance"></i> LogList
+            <i class="fa-li fa fa-ambulance"></i> LogList
         </a>
     </li>
     <li>
         <a href="xmpp:codingteam@conference.jabber.ru?join">
-            <i class="fa fa-lightbulb-o"></i> XMPP conference
+            <i class="fa-li fa fa-lightbulb-o"></i> XMPP conference
         </a>
     </li>
 </ul>


### PR DESCRIPTION
A picture is worth a thousand words; so here's "before":
![2016-10-17-172706_1366x768_scrot](https://cloud.githubusercontent.com/assets/118875/19441790/ac3aad6e-948f-11e6-8b42-7649cb3110b3.png)
and here's "after":
![2016-10-17-172707_1366x768_scrot](https://cloud.githubusercontent.com/assets/118875/19441796/b3e74c52-948f-11e6-8d68-067549116847.png)

Did it according to the [official guide](http://fontawesome.io/examples/). Funtoo Linux doesn't have .NET Core ebuilds, so instead of proper testing I just recreated the changes in Firefox Inspector.