### PR TITLE
Update default timezone offset

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -1,7 +1,7 @@
 {
     "CtorSettings": {
         "LogUrlPrefix": "https://codingteam.org.ru/_logs/codingteam%40conference.jabber.ru",
-        "LogTimeZoneOffset": 4
+        "LogTimeZoneOffset": 3
     },
     "Logging": {
         "IncludeScopes": false,


### PR DESCRIPTION
After we switched the logs from http://0xd34df00d.me to https://chatlogs.jabber.ru (see https://github.com/codingteam/devops/pull/17), our timezone should be updated.