### PR TITLE
Update copyright year

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -20,7 +20,7 @@
             <div id="main" role="main">
                 @RenderBody()
             </div>
-            <footer>© 2017 <a href="https://github.com/codingteam/codingteam.org.ru">codingteam</a></footer>
+            <footer>© 2014&ndash;2018 <a href="https://github.com/codingteam/codingteam.org.ru">codingteam</a></footer>
         </div>
     </body>
 </html>


### PR DESCRIPTION
1. Replaced a single copyright with a range because it's more correct IMHO. Couldn't find an explanation why there was only one number before.

2. Didn't update the year in the LICENSE.md because code hasn't been updated since July 2017.