### PR TITLE
Update copyright year in template

### DIFF
--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -20,7 +20,7 @@
             <div id="main" role="main">
                 @RenderBody()
             </div>
-            <footer>© 2014&ndash;2018 <a href="https://github.com/codingteam/codingteam.org.ru">codingteam</a></footer>
+            <footer>© 2019 <a href="https://github.com/codingteam/codingteam.org.ru">codingteam</a></footer>
         </div>
     </body>
 </html>


### PR DESCRIPTION
The year of first publication was removed as per #69 it's not necessary.

Closes #69.

BTW, you forgot to tag 0.7.5 release, or just didn't push the tag to GitHub.