### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Backend
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1.4.0
+        uses: actions/setup-dotnet@v1.7.2
         with:
           dotnet-version: '3.1.201'
       - name: NuGet Cache

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    </packageSources>
+</configuration>

--- a/codingteam.org.ru.sln
+++ b/codingteam.org.ru.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
@@ -13,6 +13,7 @@ ProjectSection(SolutionItems) = preProject
 	Readme.md = Readme.md
 	Dockerfile = Dockerfile
 	.dockerignore = .dockerignore
+	NuGet.Config = NuGet.Config
 EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{339BA2DC-3628-4E8E-98CC-264B5A3625AA}"


### PR DESCRIPTION
This avoids the use of deprecated `set-env` command.